### PR TITLE
Normalize dependency version ranges to tilde

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
         "memory-cache": "~0.2.0"
     },
     "devDependencies": {
-        "@eslint/js": "*",
-        "globals": "*"
+        "@eslint/js": "~10.0.1",
+        "globals": "~17.6.0"
     },
     "license": "MIT",
     "name": "@stores.com/walmart-marketplace",


### PR DESCRIPTION
Pin the `*` devDependencies to `~` ranges at their currently installed versions, per the fleet standard of tilde-only version ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)