### PR TITLE
Scope the push trigger to main to dedupe PR test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Unscoped `push` + `pull_request` fired two Test runs per PR commit, doubling live-API load and requiring both twin checks to pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)